### PR TITLE
Added kv cache truncating and int8 quant

### DIFF
--- a/data/shakespeare_char/sampled_text_example.txt
+++ b/data/shakespeare_char/sampled_text_example.txt
@@ -1,0 +1,43 @@
+GLOUCESTER:
+Stay, he pass the rude her before heaven to you:
+And you are sinew old relish deeds your with the deeds!
+And downfarewell? othou? what's thy hand part?
+What dost thou our fear?
+
+Galthy shall not? what? what will makes remones?
+Come with a king? and now me away!
+How say you? lady!
+
+Be not your tone, and murder your me!
+Go not I prove the my consultion should us me!
+
+But do my dream! broke, then cattize, mother well!
+
+Provokes a word.
+
+FRIAR LAURENCE:
+Shall we me? My bastard saints then well depart
+And work to--
+This good wise out. The cuship for me:
+Parting between't:
+When I can show him and this.
+
+RICHMOND:
+So thing then now?
+
+CATESBY:
+A gentle path cedit, bith the part from the hour,
+When all be spleasure in the place?
+
+Beather than post?
+
+TYRRAY:
+The glesses of my prayers women at the rest.
+
+BRAKENGHARD IVI:
+Pardon this our naked anger,
+Trust to the severed banishment with the fear.
+
+JULIET:
+Therefore, this commit fear it in his deposes.
+You may, set whence another of thi


### PR DESCRIPTION
This pull request completes assignment 1 and 2 of the tutorial.
1 is done by using only the last block size tokens in kv cache.
2 is done by implementing per token int8 affine quantization.
The example of sampled text is in the file _sample_text_example.txt_

If you could quickly check if the code is correct, I would be very grateful!
Unfortunately couldn't reach you anywhere else, so trying out here.

Thank you in advance!